### PR TITLE
Configure db_type using strings

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -72,6 +72,7 @@ defmodule Extreme do
 
   def handle_cast({:connect, connection_settings, attempt}, state) do
     db_type = Keyword.get(connection_settings, :db_type, :node)
+    |> cast_to_atom
     case connect db_type, connection_settings, attempt do
       {:ok, socket} -> {:noreply, %{state|socket: socket}}
       error         -> {:stop, error, state}
@@ -111,6 +112,7 @@ defmodule Extreme do
           Logger.warn "Error connecting to EventStore @ #{host}:#{port}. Will retry in #{reconnect_delay} ms."
           :timer.sleep reconnect_delay
           db_type = Keyword.get(connection_settings, :db_type, :node)
+          |> cast_to_atom
           connect db_type, connection_settings, attempt + 1
         else
           {:error, :max_attempt_exceeded}

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -243,4 +243,18 @@ defmodule Extreme do
       subscription -> GenServer.cast subscription, Response.reply(response)
     end
   end
+
+  @doc """
+  Cast the provided value to an atom if appropriate.
+  If the provided value is a string, convert it to an atom.
+  """
+  def cast_to_atom(value) when is_binary(value),
+    do: String.to_atom(value)
+
+  @doc """
+  Cast the provided value to an atom if appropriate.
+  If the provided value is not a string, return it as-is.
+  """
+  def cast_to_atom(value) when not is_binary(value),
+    do: value
 end

--- a/test/cast_to_atom_test.exs
+++ b/test/cast_to_atom_test.exs
@@ -1,0 +1,23 @@
+defmodule CastToAtomTest do
+  use ExUnit.Case
+  import Extreme, only: [cast_to_atom: 1]
+
+  test "converts strings to atoms" do
+    assert cast_to_atom("node") == :node
+    assert cast_to_atom("cluster") == :cluster
+    assert cast_to_atom("cluster_dns") == :cluster_dns
+  end
+
+  test "leaves atoms untouched" do
+    assert cast_to_atom(:node) == :node
+    assert cast_to_atom(:cluster) == :cluster
+    assert cast_to_atom(:cluster_dns) == :cluster_dns
+  end
+
+  test "leaves other types untouched" do
+    assert cast_to_atom(1) == 1
+    assert cast_to_atom(2.0) == 2.0
+    assert cast_to_atom(true) == true
+    assert cast_to_atom('hello world') == 'hello world'
+  end
+end


### PR DESCRIPTION
We require the ability to supply the `db_type` parameter from environment variables, which currently expects an atom.  This is easy enough to do in dev & test environments, but becomes more complicated when we use exrm to build prod releases.  

This pull request adds the function `cast_to_atom` and is applied where `db_type` is pulled from config in the `Extreme` module.  If the parameter comes in as a string, it will be converted to an atom.  If not, the value is returned as-is.  Unit tests have been added in a separate test module, `CastToAtomTest`.

Additionally, I was unable to compile the app in the `:dev` environment due to the file `config/dev.exs` being missing, so I added an empty placeholder for that.  
