### PR TITLE
implements generic command decoding / encoding

### DIFF
--- a/include/TcpCommands.cs
+++ b/include/TcpCommands.cs
@@ -1,0 +1,80 @@
+// https://raw.githubusercontent.com/EventStore/EventStore/master/src/EventStore.ClientAPI/SystemData/TcpCommand.cs
+namespace EventStore.ClientAPI.SystemData
+{
+    internal enum TcpCommand: byte
+    {
+        HeartbeatRequestCommand = 0x01,
+        HeartbeatResponseCommand = 0x02,
+
+        Ping = 0x03,
+        Pong = 0x04,
+
+        PrepareAck = 0x05,
+        CommitAck = 0x06,
+
+        SlaveAssignment = 0x07,
+        CloneAssignment = 0x08,
+
+        SubscribeReplica = 0x10,
+        ReplicaLogPositionAck = 0x11,
+        CreateChunk = 0x12,
+        RawChunkBulk = 0x13,
+        DataChunkBulk = 0x14,
+        ReplicaSubscriptionRetry = 0x15,
+        ReplicaSubscribed = 0x16,
+
+        // CLIENT COMMANDS
+//        CreateStream = 0x80,
+//        CreateStreamCompleted = 0x81,
+
+        WriteEvents = 0x82,
+        WriteEventsCompleted = 0x83,
+
+        TransactionStart = 0x84,
+        TransactionStartCompleted = 0x85,
+        TransactionWrite = 0x86,
+        TransactionWriteCompleted = 0x87,
+        TransactionCommit = 0x88,
+        TransactionCommitCompleted = 0x89,
+
+        DeleteStream = 0x8A,
+        DeleteStreamCompleted = 0x8B,
+
+        ReadEvent = 0xB0,
+        ReadEventCompleted = 0xB1,
+        ReadStreamEventsForward = 0xB2,
+        ReadStreamEventsForwardCompleted = 0xB3,
+        ReadStreamEventsBackward = 0xB4,
+        ReadStreamEventsBackwardCompleted = 0xB5,
+        ReadAllEventsForward = 0xB6,
+        ReadAllEventsForwardCompleted = 0xB7,
+        ReadAllEventsBackward = 0xB8,
+        ReadAllEventsBackwardCompleted = 0xB9,
+
+        SubscribeToStream = 0xC0,
+        SubscriptionConfirmation = 0xC1,
+        StreamEventAppeared = 0xC2,
+        UnsubscribeFromStream = 0xC3,
+        SubscriptionDropped = 0xC4,
+        ConnectToPersistentSubscription = 0xC5,
+        PersistentSubscriptionConfirmation = 0xC6,
+        PersistentSubscriptionStreamEventAppeared = 0xC7,
+        CreatePersistentSubscription = 0xC8,
+        CreatePersistentSubscriptionCompleted = 0xC9,
+        DeletePersistentSubscription = 0xCA,
+        DeletePersistentSubscriptionCompleted = 0xCB,
+        PersistentSubscriptionAckEvents = 0xCC,
+        PersistentSubscriptionNakEvents = 0xCD,
+        UpdatePersistentSubscription = 0xCE,
+        UpdatePersistentSubscriptionCompleted = 0xCF,
+
+        ScavengeDatabase = 0xD0,
+        ScavengeDatabaseCompleted = 0xD1,
+
+        BadRequest = 0xF0,
+        NotHandled = 0xF1,
+        Authenticate = 0xF2,
+        Authenticated = 0xF3,
+        NotAuthenticated = 0xF4
+   }
+}

--- a/lib/message_command_reader.ex
+++ b/lib/message_command_reader.ex
@@ -1,0 +1,67 @@
+defmodule Extreme.MessageCommandReader do
+  @moduledoc """
+  used only for compile-time generation of encode / decode functions in message resolver
+  """
+  @src Path.expand("../include/TcpCommands.cs", __DIR__)
+  @available_proto_modules Extreme.Messages.defs
+    |> Enum.filter(fn({{t, _}, _})-> t == :msg end)
+    |> Enum.map(fn({{_, m}, _})-> m end)
+    |> Enum.sort(fn(a, b)-> Atom.to_string(a) < Atom.to_string(b) end)
+
+  @doc """
+  all modules defined by the event_store.proto file
+  """
+  def available_proto_modules do
+    @available_proto_modules
+  end
+
+  @doc """
+  TCP commands generated from the `include/TcpCommands.cs` file
+  possible items
+    - `{:heartbeat_response_command, false, 2}` (no proto matched)
+    - `{:write_events_completed, Extreme.Messages.WriteEventsCompleted, 131}`
+  """
+  def tcp_commands do
+    @src
+    |> File.read
+    |> ok
+    |> String.split("\n")
+    |> Enum.filter(&(&1 =~ ~r/=/))
+    |> Enum.reject(&(&1 =~ ~r/\/\//))
+    |> Enum.map(&split/1)
+    |> Enum.map(&convert/1)
+  end
+
+  defp ok({:ok, v}), do: v
+
+  defp split(line) do
+    line
+    |> String.replace(",", "")
+    |> String.split("=")
+    |> Enum.map(&(String.strip(&1)))
+  end
+
+  defp convert([cmd, code]) do
+    {to_command(cmd), to_proto(cmd), to_code(code)}
+  end
+
+  defp to_code("0x" <> code) when is_binary(code) do
+    code |> :erlang.binary_to_integer(16)
+  end
+
+  defp to_command(cmd) when is_binary(cmd) do
+    cmd |> Macro.underscore |> String.to_atom
+  end
+
+  defp to_proto(cmd) when is_binary(cmd) do
+    mod = to_module(cmd)
+    case mod in available_proto_modules do
+      true  -> mod
+      false -> false
+    end
+  end
+
+  defp to_module(cmd) do
+    "Extreme.Messages.#{cmd}" |> Code.eval_string  |> elem(0)
+  end
+end

--- a/lib/message_command_reader.ex
+++ b/lib/message_command_reader.ex
@@ -15,6 +15,18 @@ defmodule Extreme.MessageCommandReader do
     @available_proto_modules
   end
 
+  def special?(type) do
+    type in [
+      :read_stream_events_forward,
+      :read_stream_events_forward_completed,
+      :read_stream_events_backward,
+      :read_stream_events_backward_completed,
+      :read_all_events_forward,
+      :read_all_events_forward_completed,
+      :read_all_events_backward,
+      :read_all_events_backward_completed]
+  end
+
   @doc """
   TCP commands generated from the `include/TcpCommands.cs` file
   possible items

--- a/lib/message_resolver_new.ex
+++ b/lib/message_resolver_new.ex
@@ -1,0 +1,48 @@
+defmodule Extreme.MessageResolverNew do
+  all   = Extreme.MessageCommandReader.tcp_commands
+  plain = all |> Enum.filter(fn({_,b,_})-> b == false end)
+  proto = all |> Enum.filter(fn({_,b,_})-> b != false end)
+  # leftover protos without automatic mapping to command
+  # see command_reader tests for details
+  special = [
+    {:read_stream_events_forward, Extreme.Messages.ReadStreamEvents, 178},
+    {:read_stream_events_forward_completed, Extreme.Messages.ReadStreamEventsCompleted, 179},
+    {:read_stream_events_backward, Extreme.Messages.ReadStreamEvents, 180},
+    {:read_stream_events_backward_completed, Extreme.Messages.ReadStreamEventsCompleted, 181},
+    {:read_all_events_forward, Extreme.Messages.ReadAllEvents, 182},
+    {:read_all_events_forward_completed, Extreme.Messages.ReadAllEventsCompleted, 183},
+    {:read_all_events_backward, Extreme.Messages.ReadAllEvents, 184},
+    {:read_all_events_backward_completed, Extreme.Messages.ReadAllEventsCompleted, 185},
+  ]
+
+  # first generate all decode functions (bit -> human)
+  for {type, proto_msg, bit} <- plain do
+    def decode_cmd(unquote(bit)) do
+      unquote(type)
+    end
+  end
+  for {type, proto_msg, bit} <- (proto ++ special) do
+    def decode_cmd(unquote(bit)) do
+      unquote(proto_msg)
+    end
+  end
+
+  # now reverse (human -> bit)
+  for {type, proto_msg, bit} <- plain do
+    def encode_cmd(unquote(type)) do
+      unquote(bit)
+    end
+  end
+  for {type, proto_msg, bit} <- proto do
+    def encode_cmd(unquote(proto_msg)) do
+      unquote(bit)
+    end
+  end
+
+  # # not sure if this is necessary, eg. mapping Extreme.Messages.ReadAllEvents to a bit won't work...
+  # for {type, proto_msg, bit} <- special do
+  #   def encode_cmd(unquote(type), unquote(proto_msg)) do
+  #     unquote(bit)
+  #   end
+  # end
+end

--- a/lib/message_resolver_new.ex
+++ b/lib/message_resolver_new.ex
@@ -1,9 +1,67 @@
 defmodule Extreme.MessageResolverNew do
-  all   = Extreme.MessageCommandReader.tcp_commands
+  # Extreme.MessageCommandReader.tcp_commands |> Enum.each(fn(x)-> IO.inspect x end)
+  all  = [
+    {:heartbeat_request_command, false, 1},
+    {:heartbeat_response_command, false, 2},
+    {:ping, false, 3},
+    {:pong, false, 4},
+    {:prepare_ack, false, 5},
+    {:commit_ack, false, 6},
+    {:slave_assignment, false, 7},
+    {:clone_assignment, false, 8},
+    {:subscribe_replica, false, 16},
+    {:replica_log_position_ack, false, 17},
+    {:create_chunk, false, 18},
+    {:raw_chunk_bulk, false, 19},
+    {:data_chunk_bulk, false, 20},
+    {:replica_subscription_retry, false, 21},
+    {:replica_subscribed, false, 22},
+    {:write_events, Extreme.Messages.WriteEvents, 130},
+    {:write_events_completed, Extreme.Messages.WriteEventsCompleted, 131},
+    {:transaction_start, Extreme.Messages.TransactionStart, 132},
+    {:transaction_start_completed, Extreme.Messages.TransactionStartCompleted, 133},
+    {:transaction_write, Extreme.Messages.TransactionWrite, 134},
+    {:transaction_write_completed, Extreme.Messages.TransactionWriteCompleted, 135},
+    {:transaction_commit, Extreme.Messages.TransactionCommit, 136},
+    {:transaction_commit_completed, Extreme.Messages.TransactionCommitCompleted, 137},
+    {:delete_stream, Extreme.Messages.DeleteStream, 138},
+    {:delete_stream_completed, Extreme.Messages.DeleteStreamCompleted, 139},
+    {:read_event, Extreme.Messages.ReadEvent, 176},
+    {:read_event_completed, Extreme.Messages.ReadEventCompleted, 177},
+    {:read_stream_events_forward, false, 178},
+    {:read_stream_events_forward_completed, false, 179},
+    {:read_stream_events_backward, false, 180},
+    {:read_stream_events_backward_completed, false, 181},
+    {:read_all_events_forward, false, 182},
+    {:read_all_events_forward_completed, false, 183},
+    {:read_all_events_backward, false, 184},
+    {:read_all_events_backward_completed, false, 185},
+    {:subscribe_to_stream, Extreme.Messages.SubscribeToStream, 192},
+    {:subscription_confirmation, Extreme.Messages.SubscriptionConfirmation, 193},
+    {:stream_event_appeared, Extreme.Messages.StreamEventAppeared, 194},
+    {:unsubscribe_from_stream, Extreme.Messages.UnsubscribeFromStream, 195},
+    {:subscription_dropped, Extreme.Messages.SubscriptionDropped, 196},
+    {:connect_to_persistent_subscription, Extreme.Messages.ConnectToPersistentSubscription, 197},
+    {:persistent_subscription_confirmation, Extreme.Messages.PersistentSubscriptionConfirmation, 198},
+    {:persistent_subscription_stream_event_appeared, Extreme.Messages.PersistentSubscriptionStreamEventAppeared, 199},
+    {:create_persistent_subscription, Extreme.Messages.CreatePersistentSubscription, 200},
+    {:create_persistent_subscription_completed, Extreme.Messages.CreatePersistentSubscriptionCompleted, 201},
+    {:delete_persistent_subscription, Extreme.Messages.DeletePersistentSubscription, 202},
+    {:delete_persistent_subscription_completed, Extreme.Messages.DeletePersistentSubscriptionCompleted, 203},
+    {:persistent_subscription_ack_events, Extreme.Messages.PersistentSubscriptionAckEvents, 204},
+    {:persistent_subscription_nak_events, Extreme.Messages.PersistentSubscriptionNakEvents, 205},
+    {:update_persistent_subscription, Extreme.Messages.UpdatePersistentSubscription, 206},
+    {:update_persistent_subscription_completed, Extreme.Messages.UpdatePersistentSubscriptionCompleted, 207},
+    {:scavenge_database, Extreme.Messages.ScavengeDatabase, 208},
+    {:scavenge_database_completed, Extreme.Messages.ScavengeDatabaseCompleted, 209},
+    {:bad_request, false, 240},
+    {:not_handled, Extreme.Messages.NotHandled, 241},
+    {:authenticate, false, 242},
+    {:authenticated, false, 243},
+    {:not_authenticated, false, 244}
+  ]
   plain = all |> Enum.filter(fn({_,b,_})-> b == false end)
   proto = all |> Enum.filter(fn({_,b,_})-> b != false end)
-  # leftover protos without automatic mapping to command
-  # see command_reader tests for details
   special = [
     {:read_stream_events_forward, Extreme.Messages.ReadStreamEvents, 178},
     {:read_stream_events_forward_completed, Extreme.Messages.ReadStreamEventsCompleted, 179},
@@ -16,14 +74,17 @@ defmodule Extreme.MessageResolverNew do
   ]
 
   # first generate all decode functions (bit -> human)
-  for {type, proto_msg, bit} <- plain do
-    def decode_cmd(unquote(bit)) do
-      unquote(type)
-    end
-  end
   for {type, proto_msg, bit} <- (proto ++ special) do
     def decode_cmd(unquote(bit)) do
       unquote(proto_msg)
+    end
+  end
+
+  for {type, proto_msg, bit} <- plain do
+    unless Extreme.MessageCommandReader.special?(type) do
+      def decode_cmd(unquote(bit)) do
+        unquote(type)
+      end
     end
   end
 
@@ -38,11 +99,4 @@ defmodule Extreme.MessageResolverNew do
       unquote(bit)
     end
   end
-
-  # # not sure if this is necessary, eg. mapping Extreme.Messages.ReadAllEvents to a bit won't work...
-  # for {type, proto_msg, bit} <- special do
-  #   def encode_cmd(unquote(type), unquote(proto_msg)) do
-  #     unquote(bit)
-  #   end
-  # end
 end

--- a/test/message_command_reader_test.exs
+++ b/test/message_command_reader_test.exs
@@ -1,0 +1,132 @@
+defmodule Extreme.MessageCommandReader.Test do
+  use ExUnit.Case
+
+  @tcp_commands  Extreme.MessageCommandReader.tcp_commands
+  @all_available Extreme.MessageCommandReader.available_proto_modules
+
+  @all_protos [Extreme.Messages.ConnectToPersistentSubscription,
+     Extreme.Messages.CreatePersistentSubscription,
+     Extreme.Messages.CreatePersistentSubscriptionCompleted,
+     Extreme.Messages.DeletePersistentSubscription,
+     Extreme.Messages.DeletePersistentSubscriptionCompleted,
+     Extreme.Messages.DeleteStream, Extreme.Messages.DeleteStreamCompleted,
+     Extreme.Messages.NotHandled, Extreme.Messages.PersistentSubscriptionAckEvents,
+     Extreme.Messages.PersistentSubscriptionConfirmation,
+     Extreme.Messages.PersistentSubscriptionNakEvents,
+     Extreme.Messages.PersistentSubscriptionStreamEventAppeared,
+     Extreme.Messages.ReadEvent, Extreme.Messages.ReadEventCompleted,
+     Extreme.Messages.ScavengeDatabase, Extreme.Messages.ScavengeDatabaseCompleted,
+     Extreme.Messages.StreamEventAppeared, Extreme.Messages.SubscribeToStream,
+     Extreme.Messages.SubscriptionConfirmation,
+     Extreme.Messages.SubscriptionDropped, Extreme.Messages.TransactionCommit,
+     Extreme.Messages.TransactionCommitCompleted, Extreme.Messages.TransactionStart,
+     Extreme.Messages.TransactionStartCompleted, Extreme.Messages.TransactionWrite,
+     Extreme.Messages.TransactionWriteCompleted,
+     Extreme.Messages.UnsubscribeFromStream,
+     Extreme.Messages.UpdatePersistentSubscription,
+     Extreme.Messages.UpdatePersistentSubscriptionCompleted,
+     Extreme.Messages.WriteEvents, Extreme.Messages.WriteEventsCompleted]
+
+  @all_left_protos [Extreme.Messages.EventRecord, Extreme.Messages.NewEvent,
+     Extreme.Messages.NotHandled.MasterInfo, Extreme.Messages.ReadAllEvents,
+     Extreme.Messages.ReadAllEventsCompleted, Extreme.Messages.ReadStreamEvents,
+     Extreme.Messages.ReadStreamEventsCompleted, Extreme.Messages.ResolvedEvent,
+     Extreme.Messages.ResolvedIndexedEvent]
+
+  @non_mapped_commands [{:heartbeat_request_command, false, 1},
+     {:heartbeat_response_command, false, 2}, {:ping, false, 3}, {:pong, false, 4},
+     {:prepare_ack, false, 5}, {:commit_ack, false, 6},
+     {:slave_assignment, false, 7}, {:clone_assignment, false, 8},
+     {:subscribe_replica, false, 16}, {:replica_log_position_ack, false, 17},
+     {:create_chunk, false, 18}, {:raw_chunk_bulk, false, 19},
+     {:data_chunk_bulk, false, 20}, {:replica_subscription_retry, false, 21},
+     {:replica_subscribed, false, 22},
+     {:read_stream_events_forward, false, 178},
+     {:read_stream_events_forward_completed, false, 179},
+     {:read_stream_events_backward, false, 180},
+     {:read_stream_events_backward_completed, false, 181},
+     {:read_all_events_forward, false, 182},
+     {:read_all_events_forward_completed, false, 183},
+     {:read_all_events_backward, false, 184},
+     {:read_all_events_backward_completed, false, 185},
+     {:bad_request, false, 240},
+     {:authenticate, false, 242}, {:authenticated, false, 243},
+     {:not_authenticated, false, 244}]
+
+
+  @mapped_commands [{:write_events, Extreme.Messages.WriteEvents, 130},
+     {:write_events_completed, Extreme.Messages.WriteEventsCompleted, 131},
+     {:transaction_start, Extreme.Messages.TransactionStart, 132},
+     {:transaction_start_completed, Extreme.Messages.TransactionStartCompleted,
+      133}, {:transaction_write, Extreme.Messages.TransactionWrite, 134},
+     {:transaction_write_completed, Extreme.Messages.TransactionWriteCompleted,
+      135}, {:transaction_commit, Extreme.Messages.TransactionCommit, 136},
+     {:transaction_commit_completed, Extreme.Messages.TransactionCommitCompleted,
+      137}, {:delete_stream, Extreme.Messages.DeleteStream, 138},
+     {:delete_stream_completed, Extreme.Messages.DeleteStreamCompleted, 139},
+     {:read_event, Extreme.Messages.ReadEvent, 176},
+     {:read_event_completed, Extreme.Messages.ReadEventCompleted, 177},
+     {:subscribe_to_stream, Extreme.Messages.SubscribeToStream, 192},
+     {:subscription_confirmation, Extreme.Messages.SubscriptionConfirmation, 193},
+     {:stream_event_appeared, Extreme.Messages.StreamEventAppeared, 194},
+     {:unsubscribe_from_stream, Extreme.Messages.UnsubscribeFromStream, 195},
+     {:subscription_dropped, Extreme.Messages.SubscriptionDropped, 196},
+     {:connect_to_persistent_subscription,
+      Extreme.Messages.ConnectToPersistentSubscription, 197},
+     {:persistent_subscription_confirmation,
+      Extreme.Messages.PersistentSubscriptionConfirmation, 198},
+     {:persistent_subscription_stream_event_appeared,
+      Extreme.Messages.PersistentSubscriptionStreamEventAppeared, 199},
+     {:create_persistent_subscription,
+      Extreme.Messages.CreatePersistentSubscription, 200},
+     {:create_persistent_subscription_completed,
+      Extreme.Messages.CreatePersistentSubscriptionCompleted, 201},
+     {:delete_persistent_subscription,
+      Extreme.Messages.DeletePersistentSubscription, 202},
+     {:delete_persistent_subscription_completed,
+      Extreme.Messages.DeletePersistentSubscriptionCompleted, 203},
+     {:persistent_subscription_ack_events,
+      Extreme.Messages.PersistentSubscriptionAckEvents, 204},
+     {:persistent_subscription_nak_events,
+      Extreme.Messages.PersistentSubscriptionNakEvents, 205},
+     {:update_persistent_subscription,
+      Extreme.Messages.UpdatePersistentSubscription, 206},
+     {:update_persistent_subscription_completed,
+      Extreme.Messages.UpdatePersistentSubscriptionCompleted, 207},
+     {:scavenge_database, Extreme.Messages.ScavengeDatabase, 208},
+     {:scavenge_database_completed, Extreme.Messages.ScavengeDatabaseCompleted,
+      209}, {:not_handled, Extreme.Messages.NotHandled, 241}]
+  def check(pos, el) do
+    assert @tcp_commands |> Enum.at(pos) == el
+  end
+
+  test "reads correctly" do
+    check 0,  {:heartbeat_request_command, false, 1}
+    check 1,  {:heartbeat_response_command, false, 2}
+    check 2,  {:ping, false, 3}
+    check 18, {:transaction_start_completed, Extreme.Messages.TransactionStartCompleted, 133}
+    check -1, {:not_authenticated, false, 244}
+  end
+
+  test "has correct number of recognized protos" do
+    assert @tcp_commands
+    |> Enum.reject(fn({_,b,_})-> b == false end)
+    |> Enum.count == 31
+
+    sorted_commands = @tcp_commands
+    |> Enum.reject(fn({_,b,_})-> b == false end)
+    |> Enum.map(fn({_,b,_})-> b end)
+    |> Enum.sort(fn(a,b)-> Atom.to_string(a) < Atom.to_string(b) end)
+
+    assert sorted_commands == @all_protos
+    assert (@all_available -- sorted_commands) == @all_left_protos
+  end
+
+  test "has correct number of non-proto commands" do
+    filter = fn(list)->
+      list |> Enum.filter(fn({_,b,_})-> b == false end)
+    end
+    assert filter.(@tcp_commands) == @non_mapped_commands
+    assert filter.(@tcp_commands) |> Enum.count == 27
+  end
+end

--- a/test/message_resolver_new_test.exs
+++ b/test/message_resolver_new_test.exs
@@ -1,0 +1,21 @@
+defmodule Extreme.MessageResolverNew.Test do
+  use ExUnit.Case
+  alias Extreme.MessageResolverNew
+
+  def check(bit, el) do
+    assert MessageResolverNew.decode_cmd(bit) == el
+    assert MessageResolverNew.encode_cmd(el)  == bit
+  end
+
+  test "works" do
+    check(1, :heartbeat_request_command)
+    check(2, :heartbeat_response_command)
+    Extreme.MessageCommandReader.tcp_commands
+    |> Enum.each(fn({type, proto, bit})->
+      case proto do
+        false -> check(bit, type)
+        _     -> check(bit, proto)
+      end
+    end)
+  end
+end

--- a/test/message_resolver_new_test.exs
+++ b/test/message_resolver_new_test.exs
@@ -2,20 +2,38 @@ defmodule Extreme.MessageResolverNew.Test do
   use ExUnit.Case
   alias Extreme.MessageResolverNew
 
-  def check(bit, el) do
+  def check(type, proto, bit) do
+    cond do
+      is_special?(type) -> check(type, proto, bit, :special)
+      proto == false    -> check(type, bit)
+      true              -> check(proto, bit)
+    end
+  end
+
+  # decode to proto, encode from atom (type)
+  def check(type, _proto, bit, :special) do
+    assert MessageResolverNew.decode_cmd(bit) in [
+      Extreme.Messages.ReadStreamEvents,
+      Extreme.Messages.ReadStreamEventsCompleted,
+      Extreme.Messages.ReadAllEvents,
+      Extreme.Messages.ReadAllEventsCompleted
+    ]
+
+    assert MessageResolverNew.encode_cmd(type) == bit
+  end
+  def check(el, bit) do
     assert MessageResolverNew.decode_cmd(bit) == el
     assert MessageResolverNew.encode_cmd(el)  == bit
   end
 
+  def is_special?(type) do
+    Extreme.MessageCommandReader.special?(type)
+  end
+
   test "works" do
-    check(1, :heartbeat_request_command)
-    check(2, :heartbeat_response_command)
     Extreme.MessageCommandReader.tcp_commands
     |> Enum.each(fn({type, proto, bit})->
-      case proto do
-        false -> check(bit, type)
-        _     -> check(bit, proto)
-      end
+      check(type, proto, bit)
     end)
   end
 end


### PR DESCRIPTION
problem: 
- current mapping bit to proto msgs is manual and spotty

solution / proposition: 
- generate the mapping as much as possible from the source code of TcpCommands.cs from the .Net EventSource client
- message_command_reader.ex generates a list of datastructures representing possible mappings
- MessageResolverNew has compile-time generated functions for de/encoding
- unit tests
