### PR TITLE
remove test artifacts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ List and specification of supported protobuf messages can be found in `include/e
 Instead of wrapping each and every request in elixir function, we are using `execute/2` function that takes server pid and request message:
 
 ```elixir
-assert {:ok, response} = Extreme.execute server, write_events
+{:ok, response} = Extreme.execute server, write_events()
 ```
 
 where `write_events` can be helper function like:


### PR DESCRIPTION
I found what was happening at this part of the readme description pretty confusing. I think this helps.
