### PR TITLE
upgrade poison from 2.2 to 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Extreme.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.8.0"},
-      {:poison, "~> 1.4 or ~> 2.2"},
+      {:poison, "~> 1.4 or ~> 3.0.0"},
       {:exprotobuf, "~> 1.0.0"},
       {:uuid, "~> 1.1.4" },
       {:ex_doc, ">= 0.11.4", only: [:test]},

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Extreme.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.8.0"},
-      {:poison, "~> 1.4 or ~> 3.0.0"},
+      {:poison, "~> 1.4 or ~> 2.2 or ~> 3.0.0"},
       {:exprotobuf, "~> 1.0.0"},
       {:uuid, "~> 1.1.4" },
       {:ex_doc, ">= 0.11.4", only: [:test]},


### PR DESCRIPTION
Passed the tests. But anyway, HARD DELETE stream is not passing, even with 2.2.

 1) test soft deleting stream can be done multiple times (ExtremeTest)
     test/extreme_test.exs:423
     match (=) failed
     code: {:ok, _response} = Extreme.execute(server, read_events(stream))
     rhs:  {:error, :NoStream,
            %Extreme.Messages.ReadStreamEventsCompleted{error: "", events: [],
             is_end_of_stream: true, last_commit_position: 668328,
             last_event_number: 14, next_event_number: -1, result: :NoStream}}
     stacktrace:
       test/extreme_test.exs:433: (test)
