### PR TITLE
Support persistent subscriptions on projection streams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 before_install:
   - wget http://download.geteventstore.com/binaries/EventStore-OSS-Ubuntu-${EVENT_STORE_VERSION}.tar.gz
   - tar xf EventStore*.tar.gz
-  - cd EventStore* && ./run-node.sh --mem-db 2>&1> eventstore.log &
+  - cd EventStore* && ./run-node.sh --run-projections=all --mem-db 2>&1> eventstore.log &
 
 after_scripts:
   - killall -SIGINT clusternode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
+# Changelog for Extreme v0.9.1
+  * Support persistent subscriptions on projection streams (e.g. `$ce-category`)
+
 # Changelog for Extreme v0.9.0
   * Added support for persistent connections (thanks to [@slashdotdash](https://github.com/slashdotdash))
-  * BREAKING CHANGE: Module Extreme.Messages is renamed to Extreme.Msg
+  * BREAKING CHANGE: Module `Extreme.Messages` is renamed to `Extreme.Msg`
 
 # Changelog for Extreme v0.8.1
   * Added pause, resume and patch functionalities for Extreme.Listener
 
 # Changelog for Extreme v0.8.0
   * Tested with Elixir 1.4.0 with fixed warnings
-  * Listener won't crash if ES is down. It will try to reconnect each 1sec instead of immediately 
+  * Listener won't crash if ES is down. It will try to reconnect each 1sec instead of immediately
   * Extreme.Listener.caught_up/0 callback is public now
   * Bumped up all dependency versions
 
@@ -15,23 +18,23 @@
   * When connecting to ES cluster choose mode :write (default) to prefer Master over Slave or :read for opposite
 
 # Changelog for Extreme v0.7.0
-  * When read_and_stay_subscribed/7 function is called, :caught_up message is sent to subscriber after existing events 
-    are read (or if there were no events) and before new events arrive. This is sign to your listener that you are 
+  * When read_and_stay_subscribed/7 function is called, :caught_up message is sent to subscriber after existing events
+    are read (or if there were no events) and before new events arrive. This is sign to your listener that you are
     up-to-date. If you don't have catch all handle_info/2 in your receiver this is breaking change!
 
 # Changelog for Extreme v0.6.2
   * Added Extreme.FanoutListener
   * Added inline documentation
-  
+
 # Changelog for Extreme v0.6.1
-  * Removed PersistentSubscription related proto messages since when compiled 
+  * Removed PersistentSubscription related proto messages since when compiled
     they generate files longer then 100 characters and as such release can't be built
 
 # Changelog for Extreme v0.6.0
   * Added Extreme.Listener
-  
+
 # Changelog for Extreme v0.5.5
-  * Removed PersistentSubscription related proto messages since when compiled 
+  * Removed PersistentSubscription related proto messages since when compiled
     they generate files longer then 100 characters and as such release can't be built
 
 # Changelog for Extreme v0.5.4

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add Extreme as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:extreme, "~> 0.9.0"}]
+  [{:extreme, "~> 0.9"}]
 end
 ```
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -40,5 +40,4 @@ config :logger, :console,
   metadata: [:user_id]
 
 config :ex_unit,
-#capture_log: true,
-  assert_receive_timeout: 2_000
+  assert_receive_timeout: 5_000

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -363,7 +363,7 @@ defmodule Extreme do
   end
   def handle_call({:ack, protobuf_msg, correlation_id}, _from, state) do
     {message, _correlation_id} = Request.prepare(protobuf_msg, state.credentials, correlation_id)
-    Logger.debug(fn -> "Ack received event: #{inspect protobuf_msg}" end)
+    # Logger.debug(fn -> "Ack received event: #{inspect protobuf_msg}" end)
     :ok = :gen_tcp.send(state.socket, message)
     {:reply, :ok, state}
   end

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -309,7 +309,7 @@ defmodule Extreme do
     opts = [:binary, active: :once]
     case :gen_tcp.connect(String.to_char_list(host), port, opts) do
       {:ok, socket} ->
-        Logger.info "Successfuly connected to EventStore @ #{host}:#{port}"
+        Logger.info "Successfully connected to EventStore @ #{host}:#{port}"
         :timer.send_after(1_000, :send_ping)
         {:ok, socket}
       _             ->

--- a/lib/persistent_subscription.ex
+++ b/lib/persistent_subscription.ex
@@ -23,8 +23,16 @@ defmodule Extreme.PersistentSubscription do
   end
 
   # confirm receipt of an event
-  def ack(subscription, %ExMsg.ResolvedIndexedEvent{event: event}) do
+  def ack(subscription, %{link: link}) when not is_nil(link) do
+    GenServer.call(subscription, {:ack, link.event_id})
+  end
+
+  def ack(subscription, %{event: event}) when not is_nil(event) do
     GenServer.call(subscription, {:ack, event.event_id})
+  end
+
+  def ack(subscription, event_id) when is_binary(event_id) do
+    GenServer.call(subscription, {:ack, event_id})
   end
 
   def handle_cast(:connect, %{connection_settings: connection_settings, params: params} = state) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Extreme.Mixfile do
 
   def project do
     [app: :extreme,
-     version: "0.9.0",
+     version: "0.9.1",
      elixir: "~> 1.3.0 or ~> 1.4.0",
      source_url: "https://github.com/exponentially/extreme",
      description: """

--- a/test/extreme_test.exs
+++ b/test/extreme_test.exs
@@ -532,7 +532,7 @@ defmodule ExtremeTest do
       {:ok, subscription} = Extreme.connect_to_persistent_subscription(server, subscriber, group, category_stream, buffer_size)
 
       # wait for event store persistent subscription to connect
-      :timer.sleep 1_000
+      :timer.sleep 2_000
 
       events = [%PersonCreated{name: "1"}, %PersonCreated{name: "2"}, %PersonCreated{name: "3"}]
       {:ok, _} = Extreme.execute(server, write_events(stream, events))

--- a/test/extreme_test.exs
+++ b/test/extreme_test.exs
@@ -531,6 +531,9 @@ defmodule ExtremeTest do
       {:ok, subscriber} = Subscriber.start_link(self())
       {:ok, subscription} = Extreme.connect_to_persistent_subscription(server, subscriber, group, category_stream, buffer_size)
 
+      # wait for event store persistent subscription to connect
+      :timer.sleep 1_000
+
       events = [%PersonCreated{name: "1"}, %PersonCreated{name: "2"}, %PersonCreated{name: "3"}]
       {:ok, _} = Extreme.execute(server, write_events(stream, events))
 

--- a/test/extreme_test.exs
+++ b/test/extreme_test.exs
@@ -443,7 +443,6 @@ defmodule ExtremeTest do
     {:error, :StreamDeleted, _} = Extreme.execute server, write_events(stream, events)
   end
 
-  #@tag :skip
   test "it writes 1_000 events in less then 2 seconds", %{server: server} do
     Logger.debug "TEST: it writes 1_000 events in less then 2 seconds"
     stream = "people-#{UUID.uuid1}"
@@ -470,7 +469,7 @@ defmodule ExtremeTest do
       assert response == %Extreme.Msg.CreatePersistentSubscriptionCompleted{reason: "", result: :Success}
     end
 
-    test "connect to existing persistent subscription", %{server: server} do
+    test "connect to existing persistent subscription on stream", %{server: server} do
       stream = "persistent-subscription-#{UUID.uuid4()}"
       group = "subscription-#{UUID.uuid4()}"
       buffer_size = 1
@@ -481,6 +480,40 @@ defmodule ExtremeTest do
       # subscribe to persistent subscription
       {:ok, subscriber} = Subscriber.start_link(self())
       {:ok, subscription} = Extreme.connect_to_persistent_subscription(server, subscriber, group, stream, buffer_size)
+
+      events = [%PersonCreated{name: "1"}, %PersonCreated{name: "2"}, %PersonCreated{name: "3"}]
+      {:ok, _} = Extreme.execute(server, write_events(stream, events))
+
+      # assert events are received
+      assert_receive {:on_event, event}
+      assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "1"}
+      :ok = Extreme.PersistentSubscription.ack(subscription, event)
+
+      assert_receive {:on_event, event}
+      assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "2"}
+      :ok = Extreme.PersistentSubscription.ack(subscription, event)
+
+      assert_receive {:on_event, event}
+      assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "3"}
+      :ok = Extreme.PersistentSubscription.ack(subscription, event)
+
+      # assert events came in expected order
+      assert Subscriber.received_events(subscriber) == events
+    end
+
+    test "connect to existing persistent subscription on category stream", %{server: server} do
+      stream_prefix = "persistent#{String.replace(UUID.uuid4(), "-", "")}"
+      stream = stream_prefix <> "-subscription"
+      category_stream = "$ce-" <> stream_prefix
+      group = "subscription-#{UUID.uuid4()}"
+      buffer_size = 1
+
+      # create persistent subscription with resolved links to events
+      {:ok, _} = Extreme.execute(server, create_persistent_subscription(group, category_stream, true))
+
+      # subscribe to persistent subscription
+      {:ok, subscriber} = Subscriber.start_link(self())
+      {:ok, subscription} = Extreme.connect_to_persistent_subscription(server, subscriber, group, category_stream, buffer_size)
 
       events = [%PersonCreated{name: "1"}, %PersonCreated{name: "2"}, %PersonCreated{name: "3"}]
       {:ok, _} = Extreme.execute(server, write_events(stream, events))
@@ -612,11 +645,12 @@ defmodule ExtremeTest do
     )
   end
 
-  defp create_persistent_subscription(groupName, stream) do
+  defp create_persistent_subscription(groupName, stream, resolve_link_tos \\ false)
+  defp create_persistent_subscription(groupName, stream, resolve_link_tos) do
     ExMsg.CreatePersistentSubscription.new(
       subscription_group_name: groupName,
       event_stream_id: stream,
-      resolve_link_tos: false,
+      resolve_link_tos: resolve_link_tos,
       start_from: 0,
       message_timeout_milliseconds: 10_000,
       record_statistics: false,


### PR DESCRIPTION
Allow persistent subscriptions to projection streams (e.g. `$ce-category`).

Support acknowledgement of an event received from a persistent subscription by the event, linked event, or event id.

Bump mix version to v0.9.1