### PR TITLE
Fix persistent sub event processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,22 +438,22 @@ _people_.
 
 You must acknowledge receipt, and successful processing, of each received event. The Event Store will remember the last acknowledged event. The subscription will resume from this position should the subscriber process terminate and reconnect. This simplifies the client logic - the code you must write.
 
-`Extreme.PersistentSubscription.ack/2` function is used to acknowledge receipt of an event.
+`Extreme.PersistentSubscription.ack/3` function is used to acknowledge receipt of an event.
 
 ```elixir
 receive do
-  {:on_event, event} ->
+  {:on_event, event, correlation_id} ->
     Logger.debug "New event added to stream 'people': #{inspect event}"
-    :ok = Extreme.PersistentSubscription.ack(subscription, event)
+    :ok = Extreme.PersistentSubscription.ack(subscription, event, correlation_id)
 end
 ```
 
 You must track the `subscription` PID returned from the `Extreme.connect_to_persistent_subscription/5` function as part of the process state when using a `GenServer` subscriber.
 
 ```elixir
-def handle_info({:on_event, event}, %{subscription: subscription} = state) do
+def handle_info({:on_event, event, correlation_id}, %{subscription: subscription} = state) do
   Logger.debug "New event added to stream 'people': #{inspect event}"
-  :ok = Extreme.PersistentSubscription.ack(subscription, event)
+  :ok = Extreme.PersistentSubscription.ack(subscription, event, correlation_id)
   {:noreply, state}
 end
 ```

--- a/lib/persistent_subscription.ex
+++ b/lib/persistent_subscription.ex
@@ -31,7 +31,7 @@ defmodule Extreme.PersistentSubscription do
   end
 
   def ack(subscription, event_id, correlation_id) when is_binary(event_id) do
-    GenServer.call(subscription, {:ack, event_id})
+    GenServer.call(subscription, {:ack, event_id, correlation_id})
   end
 
   def handle_cast(:connect, %{connection_settings: connection_settings, params: params} = state) do

--- a/lib/persistent_subscription.ex
+++ b/lib/persistent_subscription.ex
@@ -13,7 +13,6 @@ defmodule Extreme.PersistentSubscription do
       subscriber: subscriber,
       subscription_ref: Process.monitor(subscriber),
       subscription_id: nil,
-      correlation_id: nil,
       connection: nil,
       params: %{subscription: subscription, stream: stream, buffer_size: buffer_size},
       status: :initialized,
@@ -23,8 +22,8 @@ defmodule Extreme.PersistentSubscription do
   end
 
   # confirm receipt of an event
-  def ack(subscription, %ExMsg.ResolvedIndexedEvent{event: event}) do
-    GenServer.call(subscription, {:ack, event.event_id})
+  def ack(subscription, %ExMsg.ResolvedIndexedEvent{event: event}, correlation_id) do
+    GenServer.call(subscription, {:ack, event.event_id, correlation_id})
   end
 
   def handle_cast(:connect, %{connection_settings: connection_settings, params: params} = state) do
@@ -39,15 +38,15 @@ defmodule Extreme.PersistentSubscription do
   end
 
   def handle_cast({:ok, %ExMsg.PersistentSubscriptionStreamEventAppeared{event: event} = msg, correlation_id}, %{subscription_id: subscription_id, subscriber: subscriber} = state) do
-    Logger.debug(fn -> "Persistent subscription #{inspect subscription_id} event appeared: #{inspect msg}" end)
-    send(subscriber, {:on_event, event})
-    {:noreply, %{state | correlation_id: correlation_id}}
+    Logger.debug(fn -> "Persistent subscription #{inspect subscription_id} event appeared: #{inspect msg} correlation_id: #{inspect correlation_id}" end)
+    send(subscriber, {:on_event, event, correlation_id})
+    {:noreply, state}
   end
 
-  def handle_call({:ack, event_id}, _from, %{connection: connection, subscription_id: subscription_id, correlation_id: correlation_id} = state) do
-    Logger.debug(fn -> "Persistent subscription #{inspect subscription_id} ack event id: #{inspect event_id}" end)
+  def handle_call({:ack, event_id, correlation_id}, _from, %{connection: connection, subscription_id: subscription_id} = state) do
+    Logger.debug(fn -> "Persistent subscription #{inspect subscription_id} ack event id: #{inspect event_id} correlation_id: #{inspect correlation_id}" end)
     :ok = GenServer.call(connection, {:ack, ack_event(subscription_id, event_id), correlation_id})
-    {:reply, :ok, %{state | correlation_id: nil}}
+    {:reply, :ok, state}
   end
 
   # stop persistent subscription process when subscriber process is down

--- a/test/extreme_test.exs
+++ b/test/extreme_test.exs
@@ -146,7 +146,7 @@ defmodule ExtremeTest do
       {:noreply, %{state|received: [event|state.received]}}
     end
 
-    def handle_info({:on_event, event, correlation_id}=message, state) do
+    def handle_info({:on_event, event, _correlation_id}=message, state) do
       send state.sender, message
       {:noreply, %{state|received: [event|state.received]}}
     end
@@ -538,17 +538,17 @@ defmodule ExtremeTest do
       {:ok, _} = Extreme.execute(server, write_events(stream, events))
 
       # assert events are received
-      assert_receive {:on_event, event}
+      assert_receive {:on_event, event, correlation_id}
       assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "1"}
-      :ok = Extreme.PersistentSubscription.ack(subscription, event.event.event_id)
+      :ok = Extreme.PersistentSubscription.ack(subscription, event.event.event_id, correlation_id)
 
-      assert_receive {:on_event, event}
+      assert_receive {:on_event, event, correlation_id}
       assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "2"}
-      :ok = Extreme.PersistentSubscription.ack(subscription, event.event.event_id)
+      :ok = Extreme.PersistentSubscription.ack(subscription, event.event.event_id, correlation_id)
 
-      assert_receive {:on_event, event}
+      assert_receive {:on_event, event, correlation_id}
       assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "3"}
-      :ok = Extreme.PersistentSubscription.ack(subscription, event.event.event_id)
+      :ok = Extreme.PersistentSubscription.ack(subscription, event.event.event_id, correlation_id)
 
       # assert events came in expected order
       assert Subscriber.received_events(subscriber) == events
@@ -572,17 +572,17 @@ defmodule ExtremeTest do
       {:ok, _} = Extreme.execute(server, write_events(stream, events))
 
       # assert events are received
-      assert_receive {:on_event, event}
+      assert_receive {:on_event, event, correlation_id}
       assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "1"}
-      :ok = Extreme.PersistentSubscription.ack(subscription, event)
+      :ok = Extreme.PersistentSubscription.ack(subscription, event, correlation_id)
 
-      assert_receive {:on_event, event}
+      assert_receive {:on_event, event, correlation_id}
       assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "2"}
-      :ok = Extreme.PersistentSubscription.ack(subscription, event)
+      :ok = Extreme.PersistentSubscription.ack(subscription, event, correlation_id)
 
-      assert_receive {:on_event, event}
+      assert_receive {:on_event, event, correlation_id}
       assert :erlang.binary_to_term(event.event.data) == %PersonCreated{name: "3"}
-      :ok = Extreme.PersistentSubscription.ack(subscription, event)
+      :ok = Extreme.PersistentSubscription.ack(subscription, event, correlation_id)
 
       # assert events came in expected order
       assert Subscriber.received_events(subscriber) == events


### PR DESCRIPTION
I tried the persistent subscription code that was merged at commit b8bbade49f5caab8138261003ca26a4a09007e89. When I ran against a persistent subscription I received the following error:
```
** (EXIT from #PID<0.232.0>) exited in: GenServer.call(#PID<0.238.0>, {:ack, <<157, 241, 71, 42, 57, 10, 17, 231, 166, 197, 8, 0, 39, 106, 67, 158>>}, 5000)
         ** (EXIT) an exception was raised:
             ** (ArgumentError) argument error
                 :erlang.bit_size(nil)
                 (extreme) lib/request.ex:27: Extreme.Request.to_binary/4
                 (extreme) lib/request.ex:19: Extreme.Request.prepare/3
                 (extreme) lib/extreme.ex:365: Extreme.handle_call/3
                 (stdlib) gen_server.erl:615: :gen_server.try_handle_call/4
                 (stdlib) gen_server.erl:647: :gen_server.handle_msg/5
                 (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```
I created a unit test at commit efd9f2066e562fd339c7ae71638fc2c297c51977 called *Quickly process events on persistent subscription* which reproduces the error in file [test/extreme_test.exs](https://github.com/exponentially/extreme/commit/efd9f2066e562fd339c7ae71638fc2c297c51977) line 572.

The problem seems to be that the correlation_id is kept in the PersistentSubscription module's state, but when events and acknowledgments are processed quickly, the state becomes out of sync with the event processing.

I created code at commit 095f57a1ce0e7b30eb0785498a8c0adee86d3629 which solves the issue. The correlation_id is sent to the subscriber which is then sent back with the acknowledgment, so event processing does not lose track of the correlation_id. You can see with this version of the code the test I created now passes. And the persistent subscription I have on my system now processes successfully as well.

I'm sure there might be a different way to address this issue, but this code is at least a reference and currently allows me to use the code in my system.

Please let me know if you have any questions or suggestions.

Thank you,
Nathan Fox