### PR TITLE
Add support for persistent subscription negative acknowledgments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,13 +458,13 @@ def handle_info({:on_event, event, correlation_id}, %{subscription: subscription
 end
 ```
 
-Events can also be negatively acknowledged. They can be nak'd with a nak_action of :Park, :Retry, :Skip, or :Stop.
+Events can also be not acknowledged. They can be not acknowledged with a nack_action of :Park, :Retry, :Skip, or :Stop.
 
 ```elixir
 def handle_info({:on_event, event, correlation_id}, %{subscription: subscription} = state) do
   Logger.debug "New event added to stream 'people': #{inspect event}"
   if needs_to_retry do
-    :ok = Extreme.PersistentSubscription.nak(subscription, event, correlation_id, :Retry)
+    :ok = Extreme.PersistentSubscription.nack(subscription, event, correlation_id, :Retry)
   else
     :ok = Extreme.PersistentSubscription.ack(subscription, event, correlation_id)
   end

--- a/README.md
+++ b/README.md
@@ -458,6 +458,20 @@ def handle_info({:on_event, event, correlation_id}, %{subscription: subscription
 end
 ```
 
+Events can also be negatively acknowledged. They can be nak'd with a nak_action of :Park, :Retry, :Skip, or :Stop.
+
+```elixir
+def handle_info({:on_event, event, correlation_id}, %{subscription: subscription} = state) do
+  Logger.debug "New event added to stream 'people': #{inspect event}"
+  if needs_to_retry do
+    :ok = Extreme.PersistentSubscription.nak(subscription, event, correlation_id, :Retry)
+  else
+    :ok = Extreme.PersistentSubscription.ack(subscription, event, correlation_id)
+  end
+  {:noreply, state}
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -367,6 +367,12 @@ defmodule Extreme do
     :ok = :gen_tcp.send(state.socket, message)
     {:reply, :ok, state}
   end
+  def handle_call({:nak, protobuf_msg, correlation_id}, _from, state) do
+    {message, _correlation_id} = Request.prepare(protobuf_msg, state.credentials, correlation_id)
+    Logger.debug(fn -> "Nak received event: #{inspect protobuf_msg}" end)
+    :ok = :gen_tcp.send(state.socket, message)
+    {:reply, :ok, state}
+  end
 
   def handle_info(:send_ping, state) do
     message = Request.prepare(:ping)

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -367,9 +367,9 @@ defmodule Extreme do
     :ok = :gen_tcp.send(state.socket, message)
     {:reply, :ok, state}
   end
-  def handle_call({:nak, protobuf_msg, correlation_id}, _from, state) do
+  def handle_call({:nack, protobuf_msg, correlation_id}, _from, state) do
     {message, _correlation_id} = Request.prepare(protobuf_msg, state.credentials, correlation_id)
-    Logger.debug(fn -> "Nak received event: #{inspect protobuf_msg}" end)
+    Logger.debug(fn -> "Nack received event: #{inspect protobuf_msg}" end)
     :ok = :gen_tcp.send(state.socket, message)
     {:reply, :ok, state}
   end

--- a/lib/message_resolver.ex
+++ b/lib/message_resolver.ex
@@ -42,10 +42,10 @@ defmodule Extreme.MessageResolver do
   def encode_cmd(:unsubscribe_from_stream),                       do: 0xC3
   def encode_cmd(Msg.ConnectToPersistentSubscription),            do: 0xC5
   def encode_cmd(Msg.CreatePersistentSubscription),               do: 0xC8
-  def encode_cmd(:delete_persistent_subscription),                do: 0xCA
-  def encode_cmd(:delete_persistent_subscription_completed),      do: 0xCB
+  def encode_cmd(Msg.DeletePersistentSubscription),               do: 0xCA
+  def encode_cmd(Msg.DeletePersistentSubscriptionCompleted),      do: 0xCB
   def encode_cmd(Msg.PersistentSubscriptionAckEvents),            do: 0xCC
-  def encode_cmd(:persistent_subscription_nak_events),            do: 0xCD
+  def encode_cmd(Msg.PersistentSubscriptionNakEvents),            do: 0xCD
   def encode_cmd(:update_persistent_subscription),                do: 0xCE
   def encode_cmd(:update_persistent_subscription_completed),      do: 0xCF
 
@@ -81,6 +81,7 @@ defmodule Extreme.MessageResolver do
   def decode_cmd(0xC7),                                           do: Msg.PersistentSubscriptionStreamEventAppeared
 
   def decode_cmd(0xC9),                                           do: Msg.CreatePersistentSubscriptionCompleted
-
+  def decode_cmd(0xCB),                                           do: Msg.DeletePersistentSubscriptionCompleted
+  
   def decode_cmd(0xF4),                                           do: :not_authenticated
 end

--- a/lib/persistent_subscription.ex
+++ b/lib/persistent_subscription.ex
@@ -34,8 +34,8 @@ defmodule Extreme.PersistentSubscription do
     GenServer.call(subscription, {:ack, event_id, correlation_id})
   end
 
-  def nak(subscription, %{event: event}, correlation_id, nak_action, message \\ nil) when is_atom(nak_action) do
-    GenServer.call(subscription, {:nak, event.event_id, correlation_id, nak_action, message})
+  def nack(subscription, %{event: event}, correlation_id, nack_action, message \\ nil) when is_atom(nack_action) do
+    GenServer.call(subscription, {:nack, event.event_id, correlation_id, nack_action, message})
   end
 
   def handle_cast(:connect, %{connection_settings: connection_settings, params: params} = state) do
@@ -66,9 +66,9 @@ defmodule Extreme.PersistentSubscription do
     {:reply, :ok, state}
   end
 
-  def handle_call({:nak, event_id, correlation_id, nak_action, message}, _from, %{connection: connection, subscription_id: subscription_id} = state) do
-    Logger.debug(fn -> "Persistent subscription #{inspect subscription_id} nak event id: #{inspect event_id} correlation_id: #{inspect correlation_id} nak_action: #{inspect nak_action}" end)
-    :ok = GenServer.call(connection, {:nak, nak_event(subscription_id, event_id, nak_action, message), correlation_id})
+  def handle_call({:nack, event_id, correlation_id, nack_action, message}, _from, %{connection: connection, subscription_id: subscription_id} = state) do
+    Logger.debug(fn -> "Persistent subscription #{inspect subscription_id} nack event id: #{inspect event_id} correlation_id: #{inspect correlation_id} nack_action: #{inspect nack_action}" end)
+    :ok = GenServer.call(connection, {:nack, nack_event(subscription_id, event_id, nack_action, message), correlation_id})
     {:reply, :ok, state}
   end
 
@@ -86,12 +86,12 @@ defmodule Extreme.PersistentSubscription do
     )
   end
 
-  defp nak_event(subscription_id, event_id, nak_action, message) do
+  defp nack_event(subscription_id, event_id, nack_action, message) do
     ExMsg.PersistentSubscriptionNakEvents.new(
       subscription_id: subscription_id,
       processed_event_ids: [event_id],
       message: message,
-      action: nak_action
+      action: nack_action
     )
   end
 

--- a/lib/persistent_subscription.ex
+++ b/lib/persistent_subscription.ex
@@ -34,7 +34,12 @@ defmodule Extreme.PersistentSubscription do
     GenServer.call(subscription, {:ack, event_id, correlation_id})
   end
 
-  def nack(subscription, %{event: event}, correlation_id, nack_action, message \\ nil) when is_atom(nack_action) do
+  def nack(_, _, _, _, message \\ nil)
+  def nack(subscription, %{link: link}, correlation_id, nack_action, message) when not is_nil(link) and is_atom(nack_action) do
+    GenServer.call(subscription, {:nack, link.event_id, correlation_id, nack_action, message})
+  end
+
+  def nack(subscription, %{event: event}, correlation_id, nack_action, message) when is_atom(nack_action) do
     GenServer.call(subscription, {:nack, event.event_id, correlation_id, nack_action, message})
   end
 

--- a/lib/response.ex
+++ b/lib/response.ex
@@ -19,7 +19,7 @@ defmodule Extreme.Response do
   def reply(%{result: :Success} = data, _correlation_id),               do: {:ok, data}
   def reply(%ExMsg.SubscriptionConfirmation{} = data, _correlation_id), do: {:ok, data}
   def reply(%ExMsg.PersistentSubscriptionConfirmation{} = data, _correlation_id), do: {:ok, data}
-  #def reply(%ExMsg.SubscriptionDropped{} = data, _correlation_id),     do: {:ok, data}
+  def reply(%ExMsg.SubscriptionDropped{} = data, _correlation_id),     do: {:ok, data}
   def reply(%ExMsg.StreamEventAppeared{} = data, _correlation_id),      do: {:ok, data}
   def reply(%ExMsg.PersistentSubscriptionStreamEventAppeared{} = data, correlation_id), do: {:ok, data, correlation_id}
   def reply(%{result: _} = data, _correlation_id),                      do: {:error, data.result, data}

--- a/test/extreme_test.exs
+++ b/test/extreme_test.exs
@@ -706,7 +706,7 @@ defmodule ExtremeTest do
       def handle_info({:on_event, event, correlation_id}, %{ retry_count: retry_count, subscription: subscription } = state ) do
         Logger.debug("retry_count: #{inspect retry_count}")
         if retry_count < 2 do
-          :ok = Extreme.PersistentSubscription.nak(subscription, event, correlation_id, :Retry)
+          :ok = Extreme.PersistentSubscription.nack(subscription, event, correlation_id, :Retry)
           send(state.sender, {:on_event, event})
           {:noreply, %{ state| retry_count: retry_count + 1 }}
         else
@@ -717,7 +717,7 @@ defmodule ExtremeTest do
       end
     end
 
-    test "Try retry nak action", %{server: server} do
+    test "Try retry nack action", %{server: server} do
       stream = "persistent-subscription-#{UUID.uuid4()}"
       group = "subscription-#{UUID.uuid4()}"
 


### PR DESCRIPTION
In my particular use case I require being able to send negative acknowledgments for persistent subscription event messages.  This code adds handling for sending PersistentSubscriptionNakEvents messages.

Some notes about the code.

I added a unit test which tests sending a Retry nak. The test is *Try retry nak action* in file [extreme_test.exs](https://github.com/nathanfox/extreme/blob/f3e5b2ccba83d53d3f2b5fa3dbb2a215d33d991f/test/extreme_test.exs) line 720.

I added the ability to delete a persistent subscription. This allows for cleanup of created subscriptions in the test code.

In response.ex, the message SubscriptionDropped was commented out, but I wanted to handle this message for a persistent subscription, so I added it back. I'm not sure if this is a problem otherwise? All unit test pass and I haven't had problems in my system testing.

@slashdotdash could you please take a look at the code and let me know what you think? I really appreciate it.

If any changes are needed or I can answer any questions, please let me know.

Thank you,
Nathan Fox