### PR TITLE
Add concurrent read/write stress test

### DIFF
--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -154,7 +154,7 @@ defmodule Extreme do
   you can check `test/extreme_test.exs` file.
   """
   def execute(server, message),
-    do: GenServer.call(server, {:execute, message})
+    do: GenServer.call(server, {:execute, message}, 30_000)
 
   @doc """
   Reads events specified in `read_events`, sends them to `subscriber`

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(exclude: [:manual])


### PR DESCRIPTION
Here's a test that will reliably reproduce the deadlock in #45 for me.
I also bumped the timeout on the `Extreme.execute` call to make the deadlock a bit more apparent. I can revert that if you ever end up wanting to merge the test.

I'm curious if you're able to reproduce the deadlock as well. 

With the timeout change and the default config of the EventStore, this test should result in the Extreme process stopping with reason `:tcp_closed`. This is the EventStore closing the connection due to a heartbeat timeout, presumably because Extreme did not respond to its heartbeat ping. If you then increase the EventStore heartbeat timeout, the test will produce GenServer timeouts on the `Extreme.execute` call.
```
# /etc/eventstore/eventstore.conf
ExtTcpHeartbeatTimeout: 30000
ExtTcpHeartbeatInterval: 60000
```
