### PR TITLE
Normalize the port

### DIFF
--- a/lib/cluster_connection.ex
+++ b/lib/cluster_connection.ex
@@ -11,7 +11,7 @@ defmodule Extreme.ClusterConnection do
   def get_node(:cluster_dns, connection_settings) do
     {:ok, ips} = :inet.getaddrs(get_hostname(connection_settings), :inet, 1_000)
     gossip_timeout = Keyword.get(connection_settings, :gossip_timeout, 1_000)
-    gossip_port = Keyword.get(connection_settings, :port, 2113)
+    gossip_port = Extreme.Tools.normalize_port(Keyword.get(connection_settings, :port, 2113))
     mode = Keyword.get(connection_settings, :mode, :write)
     nodes = ips |> Enum.map(fn ip -> %{host: to_string(:inet.ntoa(ip)), port: gossip_port} end)
     gossip_with(nodes, gossip_timeout, mode)

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -327,7 +327,7 @@ defmodule Extreme do
 
   defp connect(:node, connection_settings, attempt) do
     host = Keyword.fetch!(connection_settings, :host)
-    port = Keyword.fetch!(connection_settings, :port)
+    port = Extreme.Tools.normalize_port(Keyword.fetch!(connection_settings, :port))
     connect(host, port, connection_settings, attempt)
   end
 

--- a/lib/tools.ex
+++ b/lib/tools.ex
@@ -2,4 +2,7 @@ defmodule Extreme.Tools do
   def gen_uuid do
     Keyword.get(UUID.info!(UUID.uuid1()), :binary, :undefined)
   end
+
+  def normalize_port(port) when is_binary(port), do: String.to_integer(port)
+  def normalize_port(port), do: port
 end

--- a/test/tools_test.exs
+++ b/test/tools_test.exs
@@ -1,0 +1,20 @@
+defmodule ToolsTest do
+  use ExUnit.Case
+
+  describe "normalize_port" do
+    import Extreme.Tools, only: [normalize_port: 1]
+
+    test "converts strings to integers" do
+      assert normalize_port("1") == 1
+    end
+
+    test "leaves integers untouched" do
+      assert normalize_port(1) == 1
+    end
+
+    test "leaves other types untouched" do
+      assert normalize_port(:atom) == :atom
+      assert normalize_port(true) == true
+    end
+  end
+end


### PR DESCRIPTION
`port` may be provided by environment variables, which is a **String**(not Integer).