### PR TITLE
use @config when Extreme.start_link/1 is called with empty array

### DIFF
--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -19,7 +19,8 @@ defmodule Extreme do
         }
       end
 
-      def start_link, do: Extreme.Supervisor.start_link(__MODULE__, @config)
+      def start_link(config \\ [])
+      def start_link([]), do: Extreme.Supervisor.start_link(__MODULE__, @config)
       def start_link(config), do: Extreme.Supervisor.start_link(__MODULE__, config)
 
       def ping,


### PR DESCRIPTION
This fixes:

- Starting a module that uses Extreme (i.e. `use Extreme, otp_app: :extreme`) as the child of a supervisor now correctly uses the config associated with otp_app.