### PR TITLE
use otp app configuration at runtime, not at compile time

### DIFF
--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -9,7 +9,6 @@ defmodule Extreme do
   defmacro __using__(opts \\ []) do
     quote do
       @otp_app Keyword.get(unquote(opts), :otp_app, :extreme)
-      @config Application.get_env(@otp_app, __MODULE__)
 
       def child_spec(opts) do
         %{
@@ -20,7 +19,10 @@ defmodule Extreme do
       end
 
       def start_link(config \\ [])
-      def start_link([]), do: Extreme.Supervisor.start_link(__MODULE__, @config)
+      def start_link([]) do 
+        Extreme.Supervisor.start_link(__MODULE__, Application.get_env(@otp_app, __MODULE__))
+      end
+
       def start_link(config), do: Extreme.Supervisor.start_link(__MODULE__, config)
 
       def ping,

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -19,7 +19,8 @@ defmodule Extreme do
       end
 
       def start_link(config \\ [])
-      def start_link([]) do 
+
+      def start_link([]) do
         Extreme.Supervisor.start_link(__MODULE__, Application.get_env(@otp_app, __MODULE__))
       end
 


### PR DESCRIPTION
Currently, the module variable `@config` is set and evaluated once at compile time.

This breaks releases via `distillery`, since configuration provided during runtime is not evaluated.

With this merge, the configuration is fetched during `start_link`, i.e. at runtime.