### PR TITLE
revert bad case-statement clean-up for persistent subscriptions

### DIFF
--- a/lib/extreme/shared_subscription.ex
+++ b/lib/extreme/shared_subscription.ex
@@ -84,8 +84,10 @@ defmodule Extreme.SharedSubscription do
     send(state.subscriber, {:extreme, reason})
     RequestManager._unregister_subscription(state.base_name, state.correlation_id)
 
-    Process.get(:reply_to)
-    |> GenServer.reply(reason)
+    case Process.get(:reply_to) do
+      nil -> :ok
+      from -> GenServer.reply(from, reason)
+    end
 
     {:stop, {:shutdown, reason}, state}
   end


### PR DESCRIPTION
I was just mucking around with persistent subscriptions and I found a little bug I left with this commit.

I don't really know what causes it, but when starting up a persistent subscription when the subscription group does not exist, I get an error about `GenServer.reply/2` trying to tell `nil` the `:not_found` reason code. It appears to be a pretty harmless bug, but still I don't like seeing that red text in my terminal!