### PR TITLE
Buffer StreamEventAppeared until subscription is registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changelog for extreme v1.0.5
+
+- RequestManager buffers live events received after subscription is created,
+  but before it is registered
+
 # Changelog for extreme v1.0.4
 
 - Listener.process_push callback can return `:stop`, meaning subscription should be stopped

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,7 +11,7 @@ config :ex_unit,
 
 config :extreme, TestConn,
   db_type: "node",
-  host: "localhost",
+  host: System.get_env("EVENTSTORE_HOST") || "localhost",
   port: "1113",
   username: "admin",
   password: "changeit",


### PR DESCRIPTION
When subscription is created in task, RequestManager can start receiving live events from EventStore _before_ the subscription is registered in RequestManager state, which can lead to dropping of live events because of that race condition.

Kudos to @tonyvanriet for identifying it and providing a nice test to verify it in https://github.com/exponentially/extreme/pull/77

I've blatantly copied that test and incorporated it into this PR, hoping my giving props to the guy won't make him angry 🙏🏻 