### PR TITLE
Specify lower ubuntu version for OTP compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   ES-5:
     name: ES 5.0.11
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         elixir: ['1.11.4', '1.12.3']
@@ -59,7 +59,7 @@ jobs:
 
   ES-21:
     name: ES 21.6.0
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         elixir: ['1.12.3']


### PR DESCRIPTION
this PR addresses issues with CI failing because workflows are run on ubuntu-latest which doesn't support target OTP versions anymore