### PR TITLE
Bump github actions to handle nodejs deprecation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,14 @@ jobs:
           EVENTSTORE_ENABLE_EXTERNAL_TCP: "true"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.erlang }}
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-deps-${{ matrix.elixir }}-${{ matrix.erlang }}-${{ hashFiles('mix.lock') }}
@@ -47,7 +47,7 @@ jobs:
     - name: Install dependencies
       run: mix deps.get
     - name: Restore builds cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: _build/test
         key: ${{ runner.os }}-build_test-${{ matrix.elixir }}-${{ matrix.erlang }}-${{ hashFiles('mix.lock') }}
@@ -78,14 +78,14 @@ jobs:
           EVENTSTORE_ENABLE_EXTERNAL_TCP: "true"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.erlang }}
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-deps-${{ matrix.elixir }}-${{ matrix.erlang }}-${{ hashFiles('mix.lock') }}
@@ -93,7 +93,7 @@ jobs:
     - name: Install dependencies
       run: mix deps.get
     - name: Restore builds cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: _build/test
         key: ${{ runner.os }}-build_test-${{ matrix.elixir }}-${{ matrix.erlang }}-${{ hashFiles('mix.lock') }}
@@ -124,14 +124,14 @@ jobs:
           EVENTSTORE_ENABLE_EXTERNAL_TCP: "true"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.erlang }}
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-deps-${{ matrix.elixir }}-${{ matrix.erlang }}-${{ hashFiles('mix.lock') }}
@@ -139,7 +139,7 @@ jobs:
     - name: Install dependencies
       run: mix deps.get
     - name: Restore builds cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: _build/test
         key: ${{ runner.os }}-build_test-${{ matrix.elixir }}-${{ matrix.erlang }}-${{ hashFiles('mix.lock') }}


### PR DESCRIPTION
bumps used GH actions in workflow to get rid of those annoying nodejs 12 deprecation warnings